### PR TITLE
dep: bump terminal table version

### DIFF
--- a/venice.gemspec
+++ b/venice.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "json"
   s.add_dependency "commander", "~> 4.1"
-  s.add_dependency "terminal-table", "~> 1.4"
+  s.add_dependency "terminal-table", ">= 2", "< 4"
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"


### PR DESCRIPTION
`terminal-table` is only used in the cli (`bin/iap`), not in the lib classes.
we use venice in omoikane ([here](https://github.com/moneytree/mt-omoikane/blob/trunk/Gemfile#L36)) and do not use the CLI, only the library classes.
So this should have no impact on logic implemented in omoikane.

Why upgrade this unused dependency?
I'm trying to adopt steep as a type checker for ruby and it has a [dependency on `terminal-table >=2`](https://github.com/soutaro/steep/blob/master/steep.gemspec#L38).